### PR TITLE
fix broken link to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A demo of stable diffusion in napari.
 
 This [napari] plugin was generated with [Cookiecutter] using [@napari]'s [cookiecutter-napari-plugin] template.
 
-![demo image of napari-stable-diffusion of the prompt "a unicorn and a dinosaur eating cookies and drinking tea"](./napari_stable_diffusion_demo.png)
+![demo image of napari-stable-diffusion of the prompt "a unicorn and a dinosaur eating cookies and drinking tea"](https://github.com/kephale/napari-stable-diffusion/raw/main/napari_stable_diffusion_demo.png)
 
 <!--
 Don't miss the full getting started guide to set up your new package:


### PR DESCRIPTION
Hi @kephale ,

this PR makes the screenshow show on the [napari-hub page of your plugin](https://www.napari-hub.org/plugins/napari-stable-diffusion). We need to use absolute links to make images work. After merging, you also need to release a new version to pypi to make this change effect.

Let me know if there is anything!

Best,
Robert