### PR TITLE
put parameters in right place to call the pipe

### DIFF
--- a/src/napari_stable_diffusion/_widget.py
+++ b/src/napari_stable_diffusion/_widget.py
@@ -179,9 +179,6 @@ class StableDiffusionWidget(QWidget):
         pipe = StableDiffusionPipeline.from_pretrained(
             get_stable_diffusion_model(),
             use_auth_token=MY_SECRET_TOKEN,
-            height=height,
-            width=width,
-            num_inference_steps=self.num_inference_steps.value(),
         )
         pipe.to(device)
 
@@ -200,7 +197,11 @@ class StableDiffusionWidget(QWidget):
             pipe.latents = latents
             pipe.to(device)
 
-            image_list = pipe([prompt])
+            image_list = pipe([prompt],
+                              height=height,
+                              width=width,
+                              num_inference_steps=self.num_inference_steps.value()
+            )
 
             array = np.array(image_list.images[0])
 


### PR DESCRIPTION
Hi @kephale ,

this closes #4 and allows us to modify `width`, `height` and `num_inference_steps` parameters when generating images. The parameters were passed when initating the pipe instead of when calling it.

Let me know what you think!

Best,
Robert